### PR TITLE
✨관리자 가입 기능

### DIFF
--- a/back-office/src/main/java/com/sparta/backoffice/admin/controller/AdminController.java
+++ b/back-office/src/main/java/com/sparta/backoffice/admin/controller/AdminController.java
@@ -1,0 +1,29 @@
+package com.sparta.backoffice.admin.controller;
+
+import com.sparta.backoffice.admin.dto.SignupRequestDTO;
+import com.sparta.backoffice.admin.service.AdminService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admins")
+public class AdminController {
+
+    private final AdminService adminService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<String> register(@RequestBody @Valid SignupRequestDTO requestDTO) {
+        adminService.createAdmin(requestDTO);
+        return new ResponseEntity<>(HttpStatus.CREATED);
+    }
+
+}

--- a/back-office/src/main/java/com/sparta/backoffice/admin/domain/Admin.java
+++ b/back-office/src/main/java/com/sparta/backoffice/admin/domain/Admin.java
@@ -1,0 +1,33 @@
+package com.sparta.backoffice.admin.domain;
+
+import com.sparta.backoffice.admin.type.Department;
+import com.sparta.backoffice.admin.type.Role;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "admin")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Admin {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "book_id")
+    private Long id;
+
+    @Column(name = "email", nullable = false, unique = true,length = 50)
+    private String email;
+
+    @Column(name = "password", nullable = false, length = 100)
+    private String password;
+
+    @Column(nullable = false, length = 20)
+    @Enumerated(EnumType.STRING)
+    private Department department;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Role role;
+}

--- a/back-office/src/main/java/com/sparta/backoffice/admin/dto/SignupRequestDTO.java
+++ b/back-office/src/main/java/com/sparta/backoffice/admin/dto/SignupRequestDTO.java
@@ -1,0 +1,27 @@
+package com.sparta.backoffice.admin.dto;
+
+import com.sparta.backoffice.admin.type.Department;
+import com.sparta.backoffice.admin.type.Role;
+import com.sparta.backoffice.admin.validator.ValidManager;
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+
+@Getter
+@ValidManager
+public class SignupRequestDTO {
+
+    @Email(message = "이메일 형식으로 입력하세요.")
+    @NotBlank(message = "값이 입력되지 않았습니다")
+    private String email;
+
+    @Pattern(regexp = "^((?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[\\W])).{8,15}+$")
+    @NotBlank(message = "값이 입력되지 않았습니다")
+    private String password;
+
+    @NotNull(message = "값이 입력되지 않았습니다")
+    private Department department;
+
+    @NotNull(message = "값이 입력되지 않았습니다")
+    private Role role;
+
+}

--- a/back-office/src/main/java/com/sparta/backoffice/admin/repository/AdminRepository.java
+++ b/back-office/src/main/java/com/sparta/backoffice/admin/repository/AdminRepository.java
@@ -1,0 +1,10 @@
+package com.sparta.backoffice.admin.repository;
+
+import com.sparta.backoffice.admin.domain.Admin;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AdminRepository extends JpaRepository<Admin, Long> {
+    Optional<Admin> findByEmail(String email);
+}

--- a/back-office/src/main/java/com/sparta/backoffice/admin/service/AdminService.java
+++ b/back-office/src/main/java/com/sparta/backoffice/admin/service/AdminService.java
@@ -1,0 +1,38 @@
+package com.sparta.backoffice.admin.service;
+
+import com.sparta.backoffice.admin.domain.Admin;
+import com.sparta.backoffice.admin.dto.SignupRequestDTO;
+import com.sparta.backoffice.admin.repository.AdminRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminService {
+
+    private final AdminRepository adminRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public void createAdmin(SignupRequestDTO requestDTO) {
+        String email = requestDTO.getEmail();
+        String password = passwordEncoder.encode(requestDTO.getPassword());
+
+        // 회원 중복 확인
+        Optional<Admin> checkEmail = adminRepository.findByEmail(email);
+        if (checkEmail.isPresent()) {
+            throw new IllegalArgumentException("중복된 사용자가 존재합니다");
+        }
+
+        // 사용자 등록
+        Admin admin = Admin.builder()
+                .email(email)
+                .password(password)
+                .department(requestDTO.getDepartment())
+                .role(requestDTO.getRole())
+                .build();
+        adminRepository.save(admin);
+    }
+}

--- a/back-office/src/main/java/com/sparta/backoffice/admin/type/Department.java
+++ b/back-office/src/main/java/com/sparta/backoffice/admin/type/Department.java
@@ -1,0 +1,13 @@
+package com.sparta.backoffice.admin.type;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum Department {
+
+    CURRICULUM("커리큘럼"),
+    MARKETING("마케팅"),
+    DEVELOPMENT("개발");
+
+    private final String value;
+}

--- a/back-office/src/main/java/com/sparta/backoffice/admin/type/Role.java
+++ b/back-office/src/main/java/com/sparta/backoffice/admin/type/Role.java
@@ -1,0 +1,21 @@
+package com.sparta.backoffice.admin.type;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum Role {
+
+    MANAGER(Authority.MANAGER),
+    STAFF(Authority.STAFF);
+
+    private final String authority;
+
+    public String getAuthority() {
+        return this.authority;
+    }
+
+    public static class Authority {
+        public static final String MANAGER = "ROLE_MANAGER";
+        public static final String STAFF = "ROLE_STAFF";
+    }
+}

--- a/back-office/src/main/java/com/sparta/backoffice/admin/validator/ManagerValidator.java
+++ b/back-office/src/main/java/com/sparta/backoffice/admin/validator/ManagerValidator.java
@@ -1,0 +1,36 @@
+package com.sparta.backoffice.admin.validator;
+
+import com.sparta.backoffice.admin.dto.SignupRequestDTO;
+import com.sparta.backoffice.admin.type.Department;
+import com.sparta.backoffice.admin.type.Role;
+import com.sparta.backoffice.global.exception.CustomException;
+import com.sparta.backoffice.global.exception.ExceptionCode;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ManagerValidator implements ConstraintValidator<ValidManager, SignupRequestDTO> {
+
+    @Override
+    public void initialize(ValidManager constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(SignupRequestDTO requestDTO, ConstraintValidatorContext constraintValidatorContext) {
+        if (Role.MANAGER.equals(requestDTO.getRole())) {
+            Department department = requestDTO.getDepartment();
+            if (department.equals(Department.CURRICULUM) || department.equals(Department.DEVELOPMENT)) {
+                return true;
+            } else {
+                log.error("CURRICULUM 또는 DEVELOPMENT 부서만 MANAGER 권한을 가질 수 있습니다.");
+                constraintValidatorContext.disableDefaultConstraintViolation();
+                constraintValidatorContext.buildConstraintViolationWithTemplate("CURRICULUM 또는 DEVELOPMENT 부서만 MANAGER 권한을 가질 수 있습니다.")
+                        .addConstraintViolation();
+                return false;
+            }
+        }
+        return false;
+    }
+}

--- a/back-office/src/main/java/com/sparta/backoffice/admin/validator/ValidManager.java
+++ b/back-office/src/main/java/com/sparta/backoffice/admin/validator/ValidManager.java
@@ -1,0 +1,24 @@
+package com.sparta.backoffice.admin.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import jakarta.validation.constraints.Pattern;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(
+        validatedBy = {ManagerValidator.class}
+)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.ANNOTATION_TYPE, ElementType.CONSTRUCTOR, ElementType.PARAMETER, ElementType.TYPE_USE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidManager {
+    String message() default "{com.sparta.backoffice.admin.validator.ValidManager.message}";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/back-office/src/main/java/com/sparta/backoffice/global/exception/CustomExceptionHandler.java
+++ b/back-office/src/main/java/com/sparta/backoffice/global/exception/CustomExceptionHandler.java
@@ -1,0 +1,57 @@
+package com.sparta.backoffice.global.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RestControllerAdvice
+public class CustomExceptionHandler {
+
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ResponseEntity<Map<String, String>> handleException(Exception e, HttpServletRequest request) {
+        HttpStatus status = HttpStatus.BAD_REQUEST;
+        return ResponseEntity.status(status).body(getResponse(e.getMessage(), status));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, String>> handleValidationException(MethodArgumentNotValidException e, HttpServletRequest request) {
+        BindingResult bindingResult = e.getBindingResult();
+        List<FieldError> fieldErrors = bindingResult.getFieldErrors();
+        List<ObjectError> errors = bindingResult.getAllErrors();
+        StringBuilder stringBuilder = new StringBuilder();
+        for (FieldError fieldError : fieldErrors) {
+            stringBuilder.append(fieldError.getField())
+                    .append(": ")
+                    .append(fieldError.getDefaultMessage())
+                    .append("; ");
+        }
+        for (ObjectError objectError: errors) {
+            stringBuilder.append(objectError.getDefaultMessage())
+                    .append("; ");
+        }
+        String errorMessage = stringBuilder.toString();
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(getResponse(errorMessage, HttpStatus.BAD_REQUEST));
+    }
+
+    private Map<String, String> getResponse(String message, HttpStatus status) {
+        Map<String, String> response = new HashMap<>();
+        response.put("error type", status.getReasonPhrase());
+        response.put("code", String.valueOf(status.value()));
+        response.put("message", message);
+        return response;
+    }
+
+}

--- a/back-office/src/main/java/com/sparta/backoffice/security/config/PasswordConfig.java
+++ b/back-office/src/main/java/com/sparta/backoffice/security/config/PasswordConfig.java
@@ -1,0 +1,16 @@
+package com.sparta.backoffice.security.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}


### PR DESCRIPTION
### 요약
- 관리자 가입 api 구현

### 작업사항
- SignupRequestDTO를 받아 관리자 가입 기능 구현
- SignupRequestDTO 유효성 검증 기능 구현

### 완료사항
- [x]  관리자 가입 기능
    - `이메일`, `비밀번호`, `부서`, `권한`을 저장할 수 있습니다.
        - 커리큘럼, 마케팅, 개발 `부서`가 있습니다.
        - MANAGER, STAFF `권한`이 있습니다.
            - 커리큘럼, 개발 `부서`만 MANAGER 권한을 부여 받을 수 있습니다.
        - `이메일`은  `올바른 이메일 형식`을 지켜야 합니다.
        - `비밀번호`는  `최소 8자 이상, 15자 이하이며 알파벳 대소문자(a~z, A~Z), 숫자(0~9), 특수문자`로 구성되어야 합니다.
    - 관리자가입 성공을 확인할 수 있는 값을 반환합니다.
        - ex) HTTP Status Code, Error Message …