### PR TITLE
✨강사 등록, 수정, 조회 기능

### DIFF
--- a/back-office/src/main/java/com/sparta/backoffice/global/exception/CustomExceptionHandler.java
+++ b/back-office/src/main/java/com/sparta/backoffice/global/exception/CustomExceptionHandler.java
@@ -3,6 +3,7 @@ package com.sparta.backoffice.global.exception;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.validation.ObjectError;
@@ -19,10 +20,8 @@ import java.util.Map;
 public class CustomExceptionHandler {
 
     @ExceptionHandler(Exception.class)
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ResponseEntity<Map<String, String>> handleException(Exception e, HttpServletRequest request) {
-        HttpStatus status = HttpStatus.BAD_REQUEST;
-        return ResponseEntity.status(status).body(getResponse(e.getMessage(), status));
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(getResponse(e.getMessage(), HttpStatus.BAD_REQUEST));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
@@ -44,6 +43,11 @@ public class CustomExceptionHandler {
         String errorMessage = stringBuilder.toString();
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(getResponse(errorMessage, HttpStatus.BAD_REQUEST));
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<Map<String, String>> handleAccessDeniedException(AccessDeniedException e) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(getResponse(e.getMessage(), HttpStatus.FORBIDDEN));
     }
 
     private Map<String, String> getResponse(String message, HttpStatus status) {

--- a/back-office/src/main/java/com/sparta/backoffice/security/config/WebSecurityConfig.java
+++ b/back-office/src/main/java/com/sparta/backoffice/security/config/WebSecurityConfig.java
@@ -10,6 +10,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
@@ -17,6 +19,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity(securedEnabled = true)
 @RequiredArgsConstructor
 public class WebSecurityConfig {
 

--- a/back-office/src/main/java/com/sparta/backoffice/teacher/controller/TeacherController.java
+++ b/back-office/src/main/java/com/sparta/backoffice/teacher/controller/TeacherController.java
@@ -31,4 +31,11 @@ public class TeacherController {
         TeacherResponseDTO responseDTO = teacherService.updateTeacher(requestDTO, teacherId);
         return new ResponseEntity<>(responseDTO, HttpStatus.OK);
     }
+
+    @Secured({Role.Authority.STAFF, Role.Authority.MANAGER})
+    @GetMapping("/{teacherId}")
+    public ResponseEntity<TeacherResponseDTO> readTeacher(@PathVariable Long teacherId) {
+        TeacherResponseDTO responseDTO = teacherService.readTeacher(teacherId);
+        return new ResponseEntity<>(responseDTO, HttpStatus.OK);
+    }
 }

--- a/back-office/src/main/java/com/sparta/backoffice/teacher/controller/TeacherController.java
+++ b/back-office/src/main/java/com/sparta/backoffice/teacher/controller/TeacherController.java
@@ -1,0 +1,30 @@
+package com.sparta.backoffice.teacher.controller;
+
+import com.sparta.backoffice.admin.type.Role;
+import com.sparta.backoffice.teacher.domain.Teacher;
+import com.sparta.backoffice.teacher.dto.TeacherRequestDTO;
+import com.sparta.backoffice.teacher.dto.TeacherResponseDTO;
+import com.sparta.backoffice.teacher.service.TeacherService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/admins/teachers")
+@RequiredArgsConstructor
+public class TeacherController {
+
+    private final TeacherService teacherService;
+
+    @Secured({Role.Authority.STAFF, Role.Authority.MANAGER})
+    @PostMapping()
+    public ResponseEntity<TeacherResponseDTO> createTeacher(@RequestBody TeacherRequestDTO requestDTO) {
+        TeacherResponseDTO responseDTO = teacherService.createTeacher(requestDTO);
+        return new ResponseEntity<>(responseDTO, HttpStatus.OK);
+    }
+}

--- a/back-office/src/main/java/com/sparta/backoffice/teacher/controller/TeacherController.java
+++ b/back-office/src/main/java/com/sparta/backoffice/teacher/controller/TeacherController.java
@@ -9,10 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/admins/teachers")
@@ -25,6 +22,13 @@ public class TeacherController {
     @PostMapping()
     public ResponseEntity<TeacherResponseDTO> createTeacher(@RequestBody TeacherRequestDTO requestDTO) {
         TeacherResponseDTO responseDTO = teacherService.createTeacher(requestDTO);
+        return new ResponseEntity<>(responseDTO, HttpStatus.OK);
+    }
+
+    @Secured(Role.Authority.MANAGER)
+    @PutMapping("/{teacherId}")
+    public ResponseEntity<TeacherResponseDTO> updateTeacher(@RequestBody TeacherRequestDTO requestDTO, @PathVariable Long teacherId) {
+        TeacherResponseDTO responseDTO = teacherService.updateTeacher(requestDTO, teacherId);
         return new ResponseEntity<>(responseDTO, HttpStatus.OK);
     }
 }

--- a/back-office/src/main/java/com/sparta/backoffice/teacher/domain/Teacher.java
+++ b/back-office/src/main/java/com/sparta/backoffice/teacher/domain/Teacher.java
@@ -1,5 +1,6 @@
 package com.sparta.backoffice.teacher.domain;
 
+import com.sparta.backoffice.teacher.dto.TeacherRequestDTO;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -32,4 +33,11 @@ public class Teacher {
 
     @Column(name = "introduce", nullable = false, length = 150)
     private String introduce;
+
+    public void update(TeacherRequestDTO requestDTO) {
+        this.experience = requestDTO.getExperience();
+        this.company = requestDTO.getCompany();
+        this.phone = requestDTO.getPhone();
+        this.introduce = requestDTO.getIntroduce();
+    }
 }

--- a/back-office/src/main/java/com/sparta/backoffice/teacher/domain/Teacher.java
+++ b/back-office/src/main/java/com/sparta/backoffice/teacher/domain/Teacher.java
@@ -1,0 +1,35 @@
+package com.sparta.backoffice.teacher.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "teacher")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Teacher {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "teacher_id")
+    private Long id;
+
+    @Column(name = "name", nullable = false, length = 10)
+    private String name;
+
+    @Column(name = "experience", nullable = false)
+    private int experience;
+
+    @Column(name = "company", nullable = false, length = 50)
+    private String company;
+
+    @Column(name = "phone", unique = true, nullable = false, length = 15)
+    private String phone;
+
+    @Column(name = "introduce", nullable = false, length = 150)
+    private String introduce;
+}

--- a/back-office/src/main/java/com/sparta/backoffice/teacher/dto/TeacherRequestDTO.java
+++ b/back-office/src/main/java/com/sparta/backoffice/teacher/dto/TeacherRequestDTO.java
@@ -1,0 +1,13 @@
+package com.sparta.backoffice.teacher.dto;
+
+import lombok.Getter;
+
+@Getter
+public class TeacherRequestDTO {
+
+    private String name;
+    private int experience;
+    private String company;
+    private String phone;
+    private String introduce;
+}

--- a/back-office/src/main/java/com/sparta/backoffice/teacher/dto/TeacherResponseDTO.java
+++ b/back-office/src/main/java/com/sparta/backoffice/teacher/dto/TeacherResponseDTO.java
@@ -1,0 +1,14 @@
+package com.sparta.backoffice.teacher.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TeacherResponseDTO {
+    private String name;
+    private int experience;
+    private String company;
+    private String phone;
+    private String introduce;
+}

--- a/back-office/src/main/java/com/sparta/backoffice/teacher/repository/TeacherRepository.java
+++ b/back-office/src/main/java/com/sparta/backoffice/teacher/repository/TeacherRepository.java
@@ -1,0 +1,7 @@
+package com.sparta.backoffice.teacher.repository;
+
+import com.sparta.backoffice.teacher.domain.Teacher;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeacherRepository extends JpaRepository<Teacher, Long> {
+}

--- a/back-office/src/main/java/com/sparta/backoffice/teacher/service/TeacherService.java
+++ b/back-office/src/main/java/com/sparta/backoffice/teacher/service/TeacherService.java
@@ -1,0 +1,33 @@
+package com.sparta.backoffice.teacher.service;
+
+import com.sparta.backoffice.teacher.domain.Teacher;
+import com.sparta.backoffice.teacher.dto.TeacherRequestDTO;
+import com.sparta.backoffice.teacher.dto.TeacherResponseDTO;
+import com.sparta.backoffice.teacher.repository.TeacherRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TeacherService {
+
+    private final TeacherRepository teacherRepository;
+
+    public TeacherResponseDTO createTeacher(TeacherRequestDTO requestDTO) {
+        Teacher teacher = Teacher.builder()
+                .name(requestDTO.getName())
+                .experience(requestDTO.getExperience())
+                .company(requestDTO.getCompany())
+                .phone(requestDTO.getPhone())
+                .introduce(requestDTO.getIntroduce())
+                .build();
+        teacherRepository.save(teacher);
+        return TeacherResponseDTO.builder()
+                .name(teacher.getName())
+                .experience(teacher.getExperience())
+                .company(teacher.getCompany())
+                .phone(teacher.getPhone())
+                .introduce(teacher.getIntroduce())
+                .build();
+    }
+}

--- a/back-office/src/main/java/com/sparta/backoffice/teacher/service/TeacherService.java
+++ b/back-office/src/main/java/com/sparta/backoffice/teacher/service/TeacherService.java
@@ -17,6 +17,7 @@ public class TeacherService {
 
     private final TeacherRepository teacherRepository;
 
+    @Transactional
     public TeacherResponseDTO createTeacher(TeacherRequestDTO requestDTO) {
         Teacher teacher = Teacher.builder()
                 .name(requestDTO.getName())

--- a/back-office/src/main/java/com/sparta/backoffice/teacher/service/TeacherService.java
+++ b/back-office/src/main/java/com/sparta/backoffice/teacher/service/TeacherService.java
@@ -6,8 +6,12 @@ import com.sparta.backoffice.teacher.dto.TeacherResponseDTO;
 import com.sparta.backoffice.teacher.repository.TeacherRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class TeacherService {
 
@@ -22,6 +26,19 @@ public class TeacherService {
                 .introduce(requestDTO.getIntroduce())
                 .build();
         teacherRepository.save(teacher);
+        return convertToTeacherResponseDTO(teacher);
+    }
+
+    @Transactional
+    public TeacherResponseDTO updateTeacher(TeacherRequestDTO requestDTO, Long teacherId) {
+        // DB에 저장된 강사인지 확인
+        Teacher teacher = findTeacher(teacherId);
+        teacher.update(requestDTO);
+
+        return convertToTeacherResponseDTO(teacher);
+    }
+
+    private TeacherResponseDTO convertToTeacherResponseDTO(Teacher teacher) {
         return TeacherResponseDTO.builder()
                 .name(teacher.getName())
                 .experience(teacher.getExperience())
@@ -29,5 +46,13 @@ public class TeacherService {
                 .phone(teacher.getPhone())
                 .introduce(teacher.getIntroduce())
                 .build();
+    }
+
+    private Teacher findTeacher(Long teacherId) {
+        Optional<Teacher> optionalTeacher = teacherRepository.findById(teacherId);
+        if (optionalTeacher.isEmpty()) {
+            throw new RuntimeException("해당하는 강사가 없습니다.");
+        }
+        return optionalTeacher.get();
     }
 }

--- a/back-office/src/main/java/com/sparta/backoffice/teacher/service/TeacherService.java
+++ b/back-office/src/main/java/com/sparta/backoffice/teacher/service/TeacherService.java
@@ -38,6 +38,11 @@ public class TeacherService {
         return convertToTeacherResponseDTO(teacher);
     }
 
+    public TeacherResponseDTO readTeacher(Long teacherId) {
+        Teacher teacher = findTeacher(teacherId);
+        return convertToTeacherResponseDTO(teacher);
+    }
+
     private TeacherResponseDTO convertToTeacherResponseDTO(Teacher teacher) {
         return TeacherResponseDTO.builder()
                 .name(teacher.getName())


### PR DESCRIPTION
### 요약
강사 등록, 선택한 강사 정보 수정, 선택한 강사 조회 기능 구현

### 작업사항
- 강사 등록, 선택한 강사 정보 수정, 선택한 강사 조회 api 구현
- Teacher Service의 강사 등록 기능에 Transactional 어노테이션 추가

### 완료사항
- [x]  강사 등록 기능
    - `이름`, `경력(년차)`, `회사`, `전화번호`, `소개`를 저장할 수 있습니다.
        - 로그인을 통해 발급받은 JWT가 함께 요청됩니다.
        - 관리자만 강사 등록이 가능합니다.
    - 등록된 강사의 정보를 반환 받아 확인할 수 있습니다.
- [x]  선택한 강사 정보 수정 기능
    - 선택한 강사의 `경력`, `회사`, `전화번호`, `소개`를 수정할 수 있습니다.
        - 로그인을 통해 발급받은 JWT가 함께 요청됩니다.
        - MANAGER  권한을 가진 관리자만 강사 정보 수정이 가능합니다.
    - 수정된 강사의 정보를 반환 받아 확인할 수 있습니다.
- [x]  선택한 강사 조회 기능
    - 선택한 강사의 정보를 조회할 수 있습니다.
        - 로그인을 통해 발급받은 JWT가 함께 요청됩니다.
        - 관리자만 강사 조회가 가능합니다.