### PR TITLE
✨강의 등록, 수정, 조회, 삭제 기능

### DIFF
--- a/back-office/src/main/java/com/sparta/backoffice/BackOfficeApplication.java
+++ b/back-office/src/main/java/com/sparta/backoffice/BackOfficeApplication.java
@@ -2,8 +2,10 @@ package com.sparta.backoffice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class BackOfficeApplication {
 
     public static void main(String[] args) {

--- a/back-office/src/main/java/com/sparta/backoffice/lecture/controller/LectureController.java
+++ b/back-office/src/main/java/com/sparta/backoffice/lecture/controller/LectureController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/admins/lecture")
+@RequestMapping("/admins/lectures")
 @RequiredArgsConstructor
 public class LectureController {
 

--- a/back-office/src/main/java/com/sparta/backoffice/lecture/controller/LectureController.java
+++ b/back-office/src/main/java/com/sparta/backoffice/lecture/controller/LectureController.java
@@ -1,0 +1,30 @@
+package com.sparta.backoffice.lecture.controller;
+
+import com.sparta.backoffice.admin.type.Role;
+import com.sparta.backoffice.lecture.dto.LectureRequestDTO;
+import com.sparta.backoffice.lecture.dto.LectureResponseDTO;
+import com.sparta.backoffice.lecture.service.LectureService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/admins/lecture")
+@RequiredArgsConstructor
+public class LectureController {
+
+    private final LectureService lectureService;
+
+    @Secured({Role.Authority.STAFF, Role.Authority.MANAGER})
+    @PostMapping()
+    public ResponseEntity<LectureResponseDTO> createLecture(@RequestBody @Valid LectureRequestDTO requestDTO) {
+        LectureResponseDTO responseDTO = lectureService.createLecture(requestDTO);
+        return new ResponseEntity<>(responseDTO, HttpStatus.OK);
+    }
+}

--- a/back-office/src/main/java/com/sparta/backoffice/lecture/controller/LectureController.java
+++ b/back-office/src/main/java/com/sparta/backoffice/lecture/controller/LectureController.java
@@ -1,10 +1,10 @@
 package com.sparta.backoffice.lecture.controller;
 
 import com.sparta.backoffice.admin.type.Role;
-import com.sparta.backoffice.lecture.domain.Lecture;
 import com.sparta.backoffice.lecture.dto.LectureRequestDTO;
 import com.sparta.backoffice.lecture.dto.LectureResponseDTO;
 import com.sparta.backoffice.lecture.service.LectureService;
+import com.sparta.backoffice.lecture.type.Category;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -43,9 +43,16 @@ public class LectureController {
     }
 
     @Secured({Role.Authority.STAFF, Role.Authority.MANAGER})
-    @GetMapping()
-    public ResponseEntity<List<LectureResponseDTO>> readLectureByTeacher(@RequestParam Long teacherId) {
+    @GetMapping("/teachers/{teacherId}")
+    public ResponseEntity<List<LectureResponseDTO>> readLectureByTeacher(@PathVariable Long teacherId) {
         List<LectureResponseDTO> responseDTOList = lectureService.readLectureByTeacher(teacherId);
+        return new ResponseEntity<>(responseDTOList, HttpStatus.OK);
+    }
+
+    @Secured({Role.Authority.STAFF, Role.Authority.MANAGER})
+    @GetMapping("/categories/{category}")
+    public ResponseEntity<List<LectureResponseDTO>> readLectureByCategory(@PathVariable Category category) {
+        List<LectureResponseDTO> responseDTOList = lectureService.readLectureByCategory(category);
         return new ResponseEntity<>(responseDTOList, HttpStatus.OK);
     }
 }

--- a/back-office/src/main/java/com/sparta/backoffice/lecture/controller/LectureController.java
+++ b/back-office/src/main/java/com/sparta/backoffice/lecture/controller/LectureController.java
@@ -1,6 +1,7 @@
 package com.sparta.backoffice.lecture.controller;
 
 import com.sparta.backoffice.admin.type.Role;
+import com.sparta.backoffice.lecture.domain.Lecture;
 import com.sparta.backoffice.lecture.dto.LectureRequestDTO;
 import com.sparta.backoffice.lecture.dto.LectureResponseDTO;
 import com.sparta.backoffice.lecture.service.LectureService;
@@ -54,5 +55,11 @@ public class LectureController {
     public ResponseEntity<List<LectureResponseDTO>> readLectureByCategory(@PathVariable Category category) {
         List<LectureResponseDTO> responseDTOList = lectureService.readLectureByCategory(category);
         return new ResponseEntity<>(responseDTOList, HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{lectureId}")
+    public ResponseEntity<Void> deleteLecture(@PathVariable Long lectureId) {
+        lectureService.deleteLecture(lectureId);
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/back-office/src/main/java/com/sparta/backoffice/lecture/controller/LectureController.java
+++ b/back-office/src/main/java/com/sparta/backoffice/lecture/controller/LectureController.java
@@ -1,6 +1,7 @@
 package com.sparta.backoffice.lecture.controller;
 
 import com.sparta.backoffice.admin.type.Role;
+import com.sparta.backoffice.lecture.domain.Lecture;
 import com.sparta.backoffice.lecture.dto.LectureRequestDTO;
 import com.sparta.backoffice.lecture.dto.LectureResponseDTO;
 import com.sparta.backoffice.lecture.service.LectureService;
@@ -10,6 +11,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/admins/lecture")
@@ -37,5 +40,12 @@ public class LectureController {
     public ResponseEntity<LectureResponseDTO> readLecture(@PathVariable Long lectureId) {
         LectureResponseDTO responseDTO = lectureService.readLecture(lectureId);
         return new ResponseEntity<>(responseDTO, HttpStatus.OK);
+    }
+
+    @Secured({Role.Authority.STAFF, Role.Authority.MANAGER})
+    @GetMapping()
+    public ResponseEntity<List<LectureResponseDTO>> readLectureByTeacher(@RequestParam Long teacherId) {
+        List<LectureResponseDTO> responseDTOList = lectureService.readLectureByTeacher(teacherId);
+        return new ResponseEntity<>(responseDTOList, HttpStatus.OK);
     }
 }

--- a/back-office/src/main/java/com/sparta/backoffice/lecture/controller/LectureController.java
+++ b/back-office/src/main/java/com/sparta/backoffice/lecture/controller/LectureController.java
@@ -31,4 +31,11 @@ public class LectureController {
         LectureResponseDTO responseDTO = lectureService.updateLecture(requestDTO, lectureId);
         return new ResponseEntity<>(responseDTO, HttpStatus.OK);
     }
+
+    @Secured({Role.Authority.STAFF, Role.Authority.MANAGER})
+    @GetMapping("/{lectureId}")
+    public ResponseEntity<LectureResponseDTO> readLecture(@PathVariable Long lectureId) {
+        LectureResponseDTO responseDTO = lectureService.readLecture(lectureId);
+        return new ResponseEntity<>(responseDTO, HttpStatus.OK);
+    }
 }

--- a/back-office/src/main/java/com/sparta/backoffice/lecture/controller/LectureController.java
+++ b/back-office/src/main/java/com/sparta/backoffice/lecture/controller/LectureController.java
@@ -9,10 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/admins/lecture")
@@ -25,6 +22,13 @@ public class LectureController {
     @PostMapping()
     public ResponseEntity<LectureResponseDTO> createLecture(@RequestBody @Valid LectureRequestDTO requestDTO) {
         LectureResponseDTO responseDTO = lectureService.createLecture(requestDTO);
+        return new ResponseEntity<>(responseDTO, HttpStatus.OK);
+    }
+
+    @Secured(Role.Authority.MANAGER)
+    @PutMapping("/{lectureId}")
+    public ResponseEntity<LectureResponseDTO> updateLecture(@RequestBody @Valid LectureRequestDTO requestDTO, @PathVariable Long lectureId) {
+        LectureResponseDTO responseDTO = lectureService.updateLecture(requestDTO, lectureId);
         return new ResponseEntity<>(responseDTO, HttpStatus.OK);
     }
 }

--- a/back-office/src/main/java/com/sparta/backoffice/lecture/domain/Lecture.java
+++ b/back-office/src/main/java/com/sparta/backoffice/lecture/domain/Lecture.java
@@ -1,5 +1,6 @@
 package com.sparta.backoffice.lecture.domain;
 
+import com.sparta.backoffice.lecture.dto.LectureRequestDTO;
 import com.sparta.backoffice.lecture.type.Category;
 import com.sparta.backoffice.teacher.domain.Teacher;
 import jakarta.persistence.*;
@@ -37,4 +38,10 @@ public class Lecture extends Timestamped {
     @JoinColumn(name = "teacher_id")
     private Teacher teacher;
 
+    public void update(LectureRequestDTO requestDTO) {
+        this.name = requestDTO.getName();
+        this.price = requestDTO.getPrice();
+        this.introduce = requestDTO.getIntroduce();
+        this.category = requestDTO.getCategory();
+    }
 }

--- a/back-office/src/main/java/com/sparta/backoffice/lecture/domain/Lecture.java
+++ b/back-office/src/main/java/com/sparta/backoffice/lecture/domain/Lecture.java
@@ -1,0 +1,40 @@
+package com.sparta.backoffice.lecture.domain;
+
+import com.sparta.backoffice.lecture.type.Category;
+import com.sparta.backoffice.teacher.domain.Teacher;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "lecture")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Lecture extends Timestamped {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "lecture_id")
+    private Long id;
+
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "price", nullable = false)
+    private int price;
+
+    @Column(name = "introduce", nullable = false, length = 150)
+    private String introduce;
+
+    @Column(name = "category", nullable = false, length = 50)
+    @Enumerated(EnumType.STRING)
+    private Category category;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "teacher_id")
+    private Teacher teacher;
+
+}

--- a/back-office/src/main/java/com/sparta/backoffice/lecture/domain/Timestamped.java
+++ b/back-office/src/main/java/com/sparta/backoffice/lecture/domain/Timestamped.java
@@ -1,0 +1,20 @@
+package com.sparta.backoffice.lecture.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class Timestamped {
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime createdAt;
+
+}

--- a/back-office/src/main/java/com/sparta/backoffice/lecture/dto/LectureRequestDTO.java
+++ b/back-office/src/main/java/com/sparta/backoffice/lecture/dto/LectureRequestDTO.java
@@ -1,0 +1,23 @@
+package com.sparta.backoffice.lecture.dto;
+
+import com.sparta.backoffice.lecture.type.Category;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class LectureRequestDTO {
+    @NotBlank(message = "강의 이름을 입력하지 않았습니다.")
+    private String name;
+
+    private int price;
+
+    @NotBlank(message = "강의 소개를 입력하지 않았습니다.")
+    private String introduce;
+
+    @NotNull(message = "강의 카테고리를 입력하지 않았습니다")
+    private Category category;
+
+    @NotNull(message = "강사를 입력하지 않았습니다.")
+    private Long teacherId;
+}

--- a/back-office/src/main/java/com/sparta/backoffice/lecture/dto/LectureResponseDTO.java
+++ b/back-office/src/main/java/com/sparta/backoffice/lecture/dto/LectureResponseDTO.java
@@ -1,0 +1,18 @@
+package com.sparta.backoffice.lecture.dto;
+
+import com.sparta.backoffice.lecture.type.Category;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+public class LectureResponseDTO {
+    private String name;
+    private int price;
+    private String introduce;
+    private Category category;
+    private Long teacherId;
+    private LocalDateTime createdAt;
+}

--- a/back-office/src/main/java/com/sparta/backoffice/lecture/repository/LectureRepository.java
+++ b/back-office/src/main/java/com/sparta/backoffice/lecture/repository/LectureRepository.java
@@ -1,0 +1,7 @@
+package com.sparta.backoffice.lecture.repository;
+
+import com.sparta.backoffice.lecture.domain.Lecture;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LectureRepository extends JpaRepository<Lecture, Long> {
+}

--- a/back-office/src/main/java/com/sparta/backoffice/lecture/repository/LectureRepository.java
+++ b/back-office/src/main/java/com/sparta/backoffice/lecture/repository/LectureRepository.java
@@ -1,7 +1,11 @@
 package com.sparta.backoffice.lecture.repository;
 
 import com.sparta.backoffice.lecture.domain.Lecture;
+import com.sparta.backoffice.teacher.domain.Teacher;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface LectureRepository extends JpaRepository<Lecture, Long> {
+    List<Lecture> findAllByTeacherOrderByCreatedAtDesc(Teacher teacher);
 }

--- a/back-office/src/main/java/com/sparta/backoffice/lecture/repository/LectureRepository.java
+++ b/back-office/src/main/java/com/sparta/backoffice/lecture/repository/LectureRepository.java
@@ -1,6 +1,7 @@
 package com.sparta.backoffice.lecture.repository;
 
 import com.sparta.backoffice.lecture.domain.Lecture;
+import com.sparta.backoffice.lecture.type.Category;
 import com.sparta.backoffice.teacher.domain.Teacher;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -8,4 +9,6 @@ import java.util.List;
 
 public interface LectureRepository extends JpaRepository<Lecture, Long> {
     List<Lecture> findAllByTeacherOrderByCreatedAtDesc(Teacher teacher);
+
+    List<Lecture> findAllByCategoryOrderByCreatedAtDesc(Category category);
 }

--- a/back-office/src/main/java/com/sparta/backoffice/lecture/service/LectureService.java
+++ b/back-office/src/main/java/com/sparta/backoffice/lecture/service/LectureService.java
@@ -1,0 +1,54 @@
+package com.sparta.backoffice.lecture.service;
+
+import com.sparta.backoffice.lecture.domain.Lecture;
+import com.sparta.backoffice.lecture.dto.LectureRequestDTO;
+import com.sparta.backoffice.lecture.dto.LectureResponseDTO;
+import com.sparta.backoffice.lecture.repository.LectureRepository;
+import com.sparta.backoffice.teacher.domain.Teacher;
+import com.sparta.backoffice.teacher.repository.TeacherRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class LectureService {
+
+    private final LectureRepository lectureRepository;
+    private final TeacherRepository teacherRepository;
+
+    public LectureResponseDTO createLecture(LectureRequestDTO requestDTO) {
+        Teacher teacher = findTeacher(requestDTO.getTeacherId());
+
+        Lecture lecture = Lecture.builder()
+                .name(requestDTO.getName())
+                .price(requestDTO.getPrice())
+                .introduce(requestDTO.getIntroduce())
+                .category(requestDTO.getCategory())
+                .teacher(teacher)
+                .build();
+
+        lectureRepository.save(lecture);
+        return convertToLectureResponseDTO(lecture);
+    }
+
+    private LectureResponseDTO convertToLectureResponseDTO(Lecture lecture) {
+        return LectureResponseDTO.builder()
+                .name(lecture.getName())
+                .price(lecture.getPrice())
+                .introduce(lecture.getIntroduce())
+                .category(lecture.getCategory())
+                .teacherId(lecture.getTeacher().getId())
+                .createdAt(lecture.getCreatedAt())
+                .build();
+    }
+
+    private Teacher findTeacher(Long teacherId) {
+        Optional<Teacher> optionalTeacher = teacherRepository.findById(teacherId);
+        if (optionalTeacher.isEmpty()) {
+            throw new RuntimeException("해당 강사는 존재하지 않습니다.");
+        }
+        return optionalTeacher.get();
+    }
+}

--- a/back-office/src/main/java/com/sparta/backoffice/lecture/service/LectureService.java
+++ b/back-office/src/main/java/com/sparta/backoffice/lecture/service/LectureService.java
@@ -4,6 +4,7 @@ import com.sparta.backoffice.lecture.domain.Lecture;
 import com.sparta.backoffice.lecture.dto.LectureRequestDTO;
 import com.sparta.backoffice.lecture.dto.LectureResponseDTO;
 import com.sparta.backoffice.lecture.repository.LectureRepository;
+import com.sparta.backoffice.lecture.type.Category;
 import com.sparta.backoffice.teacher.domain.Teacher;
 import com.sparta.backoffice.teacher.repository.TeacherRepository;
 import lombok.RequiredArgsConstructor;
@@ -54,6 +55,15 @@ public class LectureService {
     public List<LectureResponseDTO> readLectureByTeacher(Long teacherId) {
         Teacher teacher = findTeacher(teacherId);
         List<Lecture> lectureList = lectureRepository.findAllByTeacherOrderByCreatedAtDesc(teacher);
+        List<LectureResponseDTO> responseDTOList = new ArrayList<>();
+        for (Lecture lecture : lectureList) {
+            responseDTOList.add(convertToLectureResponseDTO(lecture));
+        }
+        return responseDTOList;
+    }
+
+    public List<LectureResponseDTO> readLectureByCategory(Category category) {
+        List<Lecture> lectureList = lectureRepository.findAllByCategoryOrderByCreatedAtDesc(category);
         List<LectureResponseDTO> responseDTOList = new ArrayList<>();
         for (Lecture lecture : lectureList) {
             responseDTOList.add(convertToLectureResponseDTO(lecture));

--- a/back-office/src/main/java/com/sparta/backoffice/lecture/service/LectureService.java
+++ b/back-office/src/main/java/com/sparta/backoffice/lecture/service/LectureService.java
@@ -71,6 +71,12 @@ public class LectureService {
         return responseDTOList;
     }
 
+    @Transactional
+    public void deleteLecture(Long lectureId) {
+        Lecture lecture = findLecture(lectureId);
+        lectureRepository.delete(lecture);
+    }
+
     private LectureResponseDTO convertToLectureResponseDTO(Lecture lecture) {
         return LectureResponseDTO.builder()
                 .name(lecture.getName())

--- a/back-office/src/main/java/com/sparta/backoffice/lecture/service/LectureService.java
+++ b/back-office/src/main/java/com/sparta/backoffice/lecture/service/LectureService.java
@@ -10,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -47,6 +49,16 @@ public class LectureService {
     public LectureResponseDTO readLecture(Long lectureId) {
         Lecture lecture = findLecture(lectureId);
         return convertToLectureResponseDTO(lecture);
+    }
+
+    public List<LectureResponseDTO> readLectureByTeacher(Long teacherId) {
+        Teacher teacher = findTeacher(teacherId);
+        List<Lecture> lectureList = lectureRepository.findAllByTeacherOrderByCreatedAtDesc(teacher);
+        List<LectureResponseDTO> responseDTOList = new ArrayList<>();
+        for (Lecture lecture : lectureList) {
+            responseDTOList.add(convertToLectureResponseDTO(lecture));
+        }
+        return responseDTOList;
     }
 
     private LectureResponseDTO convertToLectureResponseDTO(Lecture lecture) {

--- a/back-office/src/main/java/com/sparta/backoffice/lecture/service/LectureService.java
+++ b/back-office/src/main/java/com/sparta/backoffice/lecture/service/LectureService.java
@@ -8,16 +8,19 @@ import com.sparta.backoffice.teacher.domain.Teacher;
 import com.sparta.backoffice.teacher.repository.TeacherRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class LectureService {
 
     private final LectureRepository lectureRepository;
     private final TeacherRepository teacherRepository;
 
+    @Transactional
     public LectureResponseDTO createLecture(LectureRequestDTO requestDTO) {
         Teacher teacher = findTeacher(requestDTO.getTeacherId());
 
@@ -33,6 +36,14 @@ public class LectureService {
         return convertToLectureResponseDTO(lecture);
     }
 
+    @Transactional
+    public LectureResponseDTO updateLecture(LectureRequestDTO requestDTO, Long lectureId) {
+        Lecture lecture = findLecture(lectureId);
+        lecture.update(requestDTO);
+
+        return convertToLectureResponseDTO(lecture);
+    }
+
     private LectureResponseDTO convertToLectureResponseDTO(Lecture lecture) {
         return LectureResponseDTO.builder()
                 .name(lecture.getName())
@@ -42,6 +53,14 @@ public class LectureService {
                 .teacherId(lecture.getTeacher().getId())
                 .createdAt(lecture.getCreatedAt())
                 .build();
+    }
+
+    private Lecture findLecture(Long lectureId) {
+        Optional<Lecture> optionalLecture = lectureRepository.findById(lectureId);
+        if (optionalLecture.isEmpty()) {
+            throw new RuntimeException("해당 강의는 존재하지 않습니다.");
+        }
+        return optionalLecture.get();
     }
 
     private Teacher findTeacher(Long teacherId) {

--- a/back-office/src/main/java/com/sparta/backoffice/lecture/service/LectureService.java
+++ b/back-office/src/main/java/com/sparta/backoffice/lecture/service/LectureService.java
@@ -44,6 +44,11 @@ public class LectureService {
         return convertToLectureResponseDTO(lecture);
     }
 
+    public LectureResponseDTO readLecture(Long lectureId) {
+        Lecture lecture = findLecture(lectureId);
+        return convertToLectureResponseDTO(lecture);
+    }
+
     private LectureResponseDTO convertToLectureResponseDTO(Lecture lecture) {
         return LectureResponseDTO.builder()
                 .name(lecture.getName())

--- a/back-office/src/main/java/com/sparta/backoffice/lecture/type/Category.java
+++ b/back-office/src/main/java/com/sparta/backoffice/lecture/type/Category.java
@@ -1,0 +1,7 @@
+package com.sparta.backoffice.lecture.type;
+
+public enum Category {
+    Spring,
+    React,
+    Node;
+}


### PR DESCRIPTION
###요약
- 강의 등록, 선택한 강의 수정, 선택한 강의 조회, 선택한 강사가 촬영한 강의 조회, 카테고리별 강의 조회, 선택한 강의 삭제 기능 구현

###작업사항
- 강의 등록, 선택한 강의 수정, 선택한 강의 조회, 선택한 강사가 촬영한 강의 조회, 카테고리별 강의 조회, 선택한 강의 삭제 api 구현
- LectureController의 url을 RESTful api 설계 규칙에 맞게 변경

###완료사항
- [x]  강의 등록 기능
    - `강의명`, `가격`, `소개`, `카테고리`, `강사`, `등록일`을 저장할 수 있습니다.
        - Spring, React, Node `카테고리`가 있습니다.
        - 강사 한 명이 여러 개의 강의를 촬영할 수도 있습니다.
        - 로그인을 통해 발급받은 JWT가 함께 요청됩니다.
        - 관리자만 강의 등록이 가능합니다.
    - 등록된 강의의 정보를 반환 받아 확인할 수 있습니다.
- [x]  선택한 강의 정보 수정 기능
    - 선택한 강의의 `강의명`, `가격`, `소개`, `카테고리`를 수정할 수 있습니다.
        - 로그인을 통해 발급받은 JWT가 함께 요청됩니다.
        - MANAGER  권한을 가진 관리자만 강의 정보 수정이 가능합니다.
    - 수정된 강의의 정보를 반환 받아 확인할 수 있습니다.
- [x]  선택한 강의 조회 기능
    - 선택한 강의의 정보를 조회할 수 있습니다.
        - 로그인을 통해 발급받은 JWT가 함께 요청됩니다.
        - 관리자만 강의 조회가 가능합니다.
- [x]  선택한 강사가 촬영한 강의 목록 조회 기능
    - 선택한 강사가 촬영한 강의를 조회할 수 있습니다.
        - 로그인을 통해 발급받은 JWT가 함께 요청됩니다.
        - 관리자만 강의 조회가 가능합니다.
    - 조회된 강의 목록은 `등록일` 기준 내림차순으로 정렬 되어있습니다.
- [x]  카테고리별 강의 목록 조회 기능
    - 선택한 카테고리에 포함된 강의를 조회할 수 있습니다.
        - 로그인을 통해 발급받은 JWT가 함께 요청됩니다.
        - 관리자만 강의 조회가 가능합니다.
    - 조회된 강의 목록은 `등록일` 기준 내림차순으로 정렬 되어있습니다.
- [x]  선택한 강의 삭제 기능
    - 선택한 강의를 삭제할 수 있습니다.
        - 로그인을 통해 발급받은 JWT가 함께 요청됩니다.
        - MANAGER  권한을 가진 관리자만 강의 삭제가 가능합니다.