### PR TITLE
🐛Admin 경로 수정

### DIFF
--- a/back-office/src/main/java/com/sparta/backoffice/admin/controller/AdminController.java
+++ b/back-office/src/main/java/com/sparta/backoffice/admin/controller/AdminController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/admins")
+@RequestMapping("/admins")
 public class AdminController {
 
     private final AdminService adminService;

--- a/back-office/src/main/java/com/sparta/backoffice/admin/domain/Admin.java
+++ b/back-office/src/main/java/com/sparta/backoffice/admin/domain/Admin.java
@@ -23,11 +23,11 @@ public class Admin {
     @Column(name = "password", nullable = false, length = 100)
     private String password;
 
-    @Column(nullable = false, length = 20)
+    @Column(name = "department", nullable = false, length = 50)
     @Enumerated(EnumType.STRING)
     private Department department;
 
-    @Column(nullable = false)
+    @Column(name = "role", nullable = false, length = 50)
     @Enumerated(EnumType.STRING)
     private Role role;
 }

--- a/back-office/src/main/java/com/sparta/backoffice/security/config/WebSecurityConfig.java
+++ b/back-office/src/main/java/com/sparta/backoffice/security/config/WebSecurityConfig.java
@@ -52,7 +52,9 @@ public class WebSecurityConfig {
         http.authorizeHttpRequests((authorizeHttpRequests) ->
                 authorizeHttpRequests
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll() // resources 접근 허용 설정
-                        .requestMatchers("/api/admins/**").permitAll()
+                        .requestMatchers("/admins/lectures**").authenticated()
+                        .requestMatchers("admins/teachers**").authenticated()
+                        .requestMatchers("/admins/**").permitAll()
                         .anyRequest().authenticated() // 그 외 모든 요청 인증처리
         );
 

--- a/back-office/src/main/java/com/sparta/backoffice/security/jwt/JwtAuthenticationFilter.java
+++ b/back-office/src/main/java/com/sparta/backoffice/security/jwt/JwtAuthenticationFilter.java
@@ -24,7 +24,7 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 
     public JwtAuthenticationFilter(JwtUtil jwtUtil) {
         this.jwtUtil = jwtUtil;
-        setFilterProcessesUrl("/api/admins/login");
+        setFilterProcessesUrl("/admins/login");
     }
 
     @Override
@@ -53,6 +53,7 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
         Role role = ((UserDetailsImpl) authResult.getPrincipal()).getAdmin().getRole();
 
         String token = jwtUtil.createToken(email, role);
+        log.info(token);
         jwtUtil.addJwtToCookie(token, response);
     }
 


### PR DESCRIPTION
### 요약
- Admin 관련 버그 수정

### 작업 사항
- Admin Entity의 department, role Column 어노테이션 수정
- AdminController의 RequestMapping url을 RESTful api 설계 규칙에 맞게 변경
- 변경된 url에 맞게 WebSecurityConfig에 설정된 경로 분할
- 변경된 url에 맞게 JwtAuthenticationFilter의 LoginProcessesUrl 수정