### PR TITLE
✨강사 삭제 기능

### DIFF
--- a/back-office/src/main/java/com/sparta/backoffice/lecture/controller/LectureController.java
+++ b/back-office/src/main/java/com/sparta/backoffice/lecture/controller/LectureController.java
@@ -57,6 +57,7 @@ public class LectureController {
         return new ResponseEntity<>(responseDTOList, HttpStatus.OK);
     }
 
+    @Secured(Role.Authority.MANAGER)
     @DeleteMapping("/{lectureId}")
     public ResponseEntity<Void> deleteLecture(@PathVariable Long lectureId) {
         lectureService.deleteLecture(lectureId);

--- a/back-office/src/main/java/com/sparta/backoffice/lecture/controller/LectureController.java
+++ b/back-office/src/main/java/com/sparta/backoffice/lecture/controller/LectureController.java
@@ -1,7 +1,6 @@
 package com.sparta.backoffice.lecture.controller;
 
 import com.sparta.backoffice.admin.type.Role;
-import com.sparta.backoffice.lecture.domain.Lecture;
 import com.sparta.backoffice.lecture.dto.LectureRequestDTO;
 import com.sparta.backoffice.lecture.dto.LectureResponseDTO;
 import com.sparta.backoffice.lecture.service.LectureService;

--- a/back-office/src/main/java/com/sparta/backoffice/teacher/controller/TeacherController.java
+++ b/back-office/src/main/java/com/sparta/backoffice/teacher/controller/TeacherController.java
@@ -38,4 +38,10 @@ public class TeacherController {
         TeacherResponseDTO responseDTO = teacherService.readTeacher(teacherId);
         return new ResponseEntity<>(responseDTO, HttpStatus.OK);
     }
+
+    @DeleteMapping("/{teacherId}")
+    public ResponseEntity<Void> deleteTeacher(@PathVariable Long teacherId) {
+        teacherService.deleteTeacher(teacherId);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
 }

--- a/back-office/src/main/java/com/sparta/backoffice/teacher/controller/TeacherController.java
+++ b/back-office/src/main/java/com/sparta/backoffice/teacher/controller/TeacherController.java
@@ -39,6 +39,7 @@ public class TeacherController {
         return new ResponseEntity<>(responseDTO, HttpStatus.OK);
     }
 
+    @Secured(Role.Authority.MANAGER)
     @DeleteMapping("/{teacherId}")
     public ResponseEntity<Void> deleteTeacher(@PathVariable Long teacherId) {
         teacherService.deleteTeacher(teacherId);

--- a/back-office/src/main/java/com/sparta/backoffice/teacher/domain/Teacher.java
+++ b/back-office/src/main/java/com/sparta/backoffice/teacher/domain/Teacher.java
@@ -1,11 +1,15 @@
 package com.sparta.backoffice.teacher.domain;
 
+import com.sparta.backoffice.lecture.domain.Lecture;
 import com.sparta.backoffice.teacher.dto.TeacherRequestDTO;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "teacher")
@@ -33,6 +37,9 @@ public class Teacher {
 
     @Column(name = "introduce", nullable = false, length = 150)
     private String introduce;
+
+    @OneToMany(mappedBy = "teacher", cascade = CascadeType.ALL)
+    private List<Lecture> lectures = new ArrayList<>();
 
     public void update(TeacherRequestDTO requestDTO) {
         this.experience = requestDTO.getExperience();

--- a/back-office/src/main/java/com/sparta/backoffice/teacher/service/TeacherService.java
+++ b/back-office/src/main/java/com/sparta/backoffice/teacher/service/TeacherService.java
@@ -47,7 +47,7 @@ public class TeacherService {
     @Transactional
     public void deleteTeacher(Long teacherId) {
         Teacher teacher = findTeacher(teacherId);
-        teacherRepository.deleteById(teacherId);
+        teacherRepository.delete(teacher);
     }
 
     private TeacherResponseDTO convertToTeacherResponseDTO(Teacher teacher) {

--- a/back-office/src/main/java/com/sparta/backoffice/teacher/service/TeacherService.java
+++ b/back-office/src/main/java/com/sparta/backoffice/teacher/service/TeacherService.java
@@ -44,6 +44,12 @@ public class TeacherService {
         return convertToTeacherResponseDTO(teacher);
     }
 
+    @Transactional
+    public void deleteTeacher(Long teacherId) {
+        Teacher teacher = findTeacher(teacherId);
+        teacherRepository.deleteById(teacherId);
+    }
+
     private TeacherResponseDTO convertToTeacherResponseDTO(Teacher teacher) {
         return TeacherResponseDTO.builder()
                 .name(teacher.getName())


### PR DESCRIPTION
### 요약
- 선택한 강세 삭제 기능 구현

### 작업사항
- 선택한 강사 삭제 api 구현
- Teacher 데이터가 삭제되면 Lecture의 자식 데이터가 삭제되도록 엔티티 관계를 양방향으로 변경, Cascade 설정

### 완료사항
- [x]  선택한 강사 삭제 기능
    - 선택한 강사를 삭제할 수 있습니다.
        - 로그인을 통해 발급받은 JWT가 함께 요청됩니다.
        - MANAGER  권한을 가진 관리자만 강사 삭제가 가능합니다.